### PR TITLE
Multiple Dynamic Route Values Bug

### DIFF
--- a/app/initializers/transition-to-dynamic.js
+++ b/app/initializers/transition-to-dynamic.js
@@ -4,8 +4,10 @@ function transitionToDynamic(name, routesWithSegments) {
   for (var i = 0; i < routes.length; i++) {
     var route = routes[i];
     var params = route.params;
+    var names = route._names;
     var routeSegments = routesWithSegments[route.name];
-    for (var param in params) {
+    for (var x = 0; x < names.length; x++) {
+      var param = names[x];
       if (!params.hasOwnProperty(param)) continue;
       var segment = params[param];
       if (routeSegments && routeSegments[param]) {


### PR DESCRIPTION
There was an issues when a route had multiple dynamic values, that in
certain cases, the dynamic values in the route were getting flipped.
The route._names keeps these in the order as they are defined in the
router.