### PR TITLE
1.13 introduced route._names not always there

### DIFF
--- a/app/initializers/transition-to-dynamic.js
+++ b/app/initializers/transition-to-dynamic.js
@@ -5,12 +5,11 @@ function transitionToDynamic(name, routesWithSegments) {
 
     // using route._names instead of route.params because
     // the latter's order is not guaranteed
-    if (route._names && route._names.forEach) {
-      route._names.forEach(param => {
-        var paramsSource = routeSegments && routeSegments[param] ? routeSegments : route.params;
-        models.push(paramsSource[param]);
-      });
-    }
+    route.handler._names.forEach(param => {
+      var paramsSource = routeSegments && routeSegments[param]
+        ? routeSegments : route.params;
+      models.push(paramsSource[param]);
+    });
   });
 
   var args = models.slice();


### PR DESCRIPTION
use alternate route.handler._names

better fix for #3
